### PR TITLE
Allow build script to use babel cmd from node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /es5
 /gh-pages
+/node_modules

--- a/bin/build-es5.sh
+++ b/bin/build-es5.sh
@@ -12,4 +12,4 @@ test -d "$es5" || mkdir -p "$es5"
 cp -rf $es6 $es5
 
 # Overwrite .js files with transpiled code
-babel --presets es2015 -d $es5 $es6 -q
+./node_modules/.bin/babel --presets es2015 -d $es5 $es6 -q


### PR DESCRIPTION
- Update `build-es5.sh` to use `node_modules/.bin/babel`
- Add `node_modules` folder to `.gitignore`

This seemed to resolve the build error for when a user does not have babel/babel-cli installed with `npm install -g babel-cli`.